### PR TITLE
Bootstrapをimport

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,4 +1,6 @@
 import './assets/main.css'
+import 'bootstrap/dist/css/bootstrap.min.css'
+import 'bootstrap'
 
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'


### PR DESCRIPTION
Bootstrapをプロジェクト全体で利用できるよう、main.tsにimportしました。
また、bootstrap.min.cssをインストールしている理由は、デプロイの際に軽量にするためです。
また、min.cssであれフル版.cssであれ、利用するタグの書き方や機能に違いはありません。